### PR TITLE
Port to SGX for tokio `1.16.1`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 
 members = [
   "tokio",
@@ -14,3 +15,6 @@ members = [
   "tests-build",
   "tests-integration",
 ]
+
+[patch.crates-io]
+mio = { git = "https://github.com/mzohreva/mio", branch = "mz/sgx-port-0.7.6" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 
 members = [
+  "runner",
   "tokio",
   "tokio-macros",
   "tokio-test",
@@ -18,3 +19,7 @@ members = [
 
 [patch.crates-io]
 mio = { git = "https://github.com/mzohreva/mio", branch = "mz/sgx-port-0.7.6" }
+enclave-runner = { git = "https://github.com/fortanix/rust-sgx", branch = "mz/async-usercalls" }
+sgxs = { git = "https://github.com/fortanix/rust-sgx", branch = "mz/async-usercalls" }
+sgx-isa = { git = "https://github.com/fortanix/rust-sgx", branch = "mz/async-usercalls" }
+sgxs-loaders = { git = "https://github.com/fortanix/rust-sgx", branch = "mz/async-usercalls" }

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -5,8 +5,13 @@ publish = false
 edition = "2018"
 
 [dependencies]
-tokio = { version = "1.5.0", path = "../tokio", features = ["full"] }
 bencher = "0.1.5"
+
+[target.'cfg(target_env = "sgx")'.dependencies]
+tokio = { version = "1.5.0", path = "../tokio", features = ["full-sgx"] }
+
+[target.'cfg(not(target_env = "sgx"))'.dependencies]
+tokio = { version = "1.5.0", path = "../tokio", features = ["full"] }
 
 [dev-dependencies]
 tokio-util = { version = "0.7.0", path = "../tokio-util", features = ["full"] }

--- a/ct.sh
+++ b/ct.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -ex
+
+cargo test
+
+pushd tokio
+cargo test --target x86_64-fortanix-unknown-sgx --features "full-sgx"
+popd

--- a/ct.sh
+++ b/ct.sh
@@ -1,7 +1,23 @@
 #!/bin/bash -ex
+repo_root=$(readlink -f $(dirname ${BASH_SOURCE[0]}))
+cd ${repo_root}
+
+source ${repo_root}/ct_env.sh
 
 cargo test
 
 pushd tokio
 cargo test --target x86_64-fortanix-unknown-sgx --features "full-sgx"
+popd
+
+pushd tokio-macros
+cargo test --target x86_64-fortanix-unknown-sgx
+popd
+
+pushd tokio-stream
+cargo test --target x86_64-fortanix-unknown-sgx
+popd
+
+pushd stress-test
+cargo test --target x86_64-fortanix-unknown-sgx
 popd

--- a/ct_env.sh
+++ b/ct_env.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -ex
+repo_root=$(readlink -f $(dirname ${BASH_SOURCE[0]}))
+cd ${repo_root}
+
+# Unfortunately, the `ftxsgx-runner-cargo` application doesn't enable us to point to a runner within the same workspace. We use a hack here by pointing to `runner` and making sure such an executable exists when running CI
+pushd runner
+cargo build
+popd
+
+export PATH=${repo_root}/target/debug/:${PATH}

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -24,6 +24,12 @@ httpdate = "1.0"
 once_cell = "1.5.2"
 rand = "0.8.3"
 
+[target.'cfg(not(target_env = "sgx"))'.dev-dependencies]
+tokio = { version = "1.0.0", path = "../tokio",features = ["full", "tracing"] }
+
+[target.'cfg(target_env = "sgx")'.dev-dependencies]
+tokio = { version = "1.0.0", path = "../tokio",features = ["full-sgx", "tracing"] }
+
 [target.'cfg(windows)'.dev-dependencies.winapi]
 version = "0.3.8"
 

--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "runner"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+aesm-client = { version = "0.2", features = ["sgxs"] }
+clap = "2.0"
+enclave-runner = "0.5"
+sgxs-loaders = "0.3.0"

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -1,0 +1,51 @@
+use aesm_client::AesmClient;
+use clap::{App, Arg};
+use enclave_runner::EnclaveBuilder;
+
+#[cfg(windows)]
+use sgxs_loaders::enclaveapi::Sgx as IsgxDevice;
+#[cfg(unix)]
+use sgxs_loaders::isgx::Device as IsgxDevice;
+
+fn main() {
+    let args = App::new("runner")
+        .arg(Arg::with_name("file").required(true))
+        .arg(
+            Arg::with_name("enclave-args")
+                .long_help(
+                    "Arguments passed to the enclave. \
+                    Note that this is not an appropriate channel for passing \
+                    secrets or security configurations to the enclave.",
+                )
+                .multiple(true),
+        )
+        .get_matches();
+
+    let file = args.value_of("file").unwrap();
+
+    let mut device = IsgxDevice::new()
+        .expect("failed to open SGX device")
+        .einittoken_provider(AesmClient::new())
+        .build();
+
+    let mut enclave_builder = EnclaveBuilder::new(file.as_ref());
+    if let Err(_) = enclave_builder.coresident_signature() {
+        enclave_builder.dummy_signature();
+    }
+
+    if let Some(enclave_args) = args.values_of("enclave-args") {
+        enclave_builder.args(enclave_args);
+    }
+
+    let enclave = enclave_builder
+        .build(&mut device)
+        .expect("failed to load SGX enclave");
+
+    match enclave.run() {
+        Err(e) => {
+            eprintln!("Error while executing SGX enclave.\n{}", e);
+            std::process::exit(-1)
+        }
+        Ok(()) => {}
+    }
+}

--- a/stress-test/Cargo.toml
+++ b/stress-test/Cargo.toml
@@ -8,7 +8,12 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+
+[target.'cfg(not(target_env = "sgx"))'.dependencies]
 tokio = { path = "../tokio/", features = ["full"] }
+
+[target.'cfg(target_env = "sgx")'.dependencies]
+tokio = { path = "../tokio/", features = ["full-sgx"] }
 
 [dev-dependencies]
 rand = "0.8"

--- a/stress-test/examples/simple_echo_tcp.rs
+++ b/stress-test/examples/simple_echo_tcp.rs
@@ -3,7 +3,7 @@ use std::{thread::sleep, time::Duration};
 
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
-    net::{TcpListener, TcpSocket},
+    net::{TcpListener, TcpStream},
     runtime::Builder,
     sync::oneshot,
 };
@@ -30,9 +30,7 @@ fn main() {
     let (tx, mut rx) = oneshot::channel();
 
     rt2.spawn(async {
-        let addr = TCP_ENDPOINT.parse().unwrap();
-        let socket = TcpSocket::new_v4().unwrap();
-        let mut stream = socket.connect(addr).await.unwrap();
+        let mut stream = TcpStream::connect(TCP_ENDPOINT).await.unwrap();
 
         let mut buff = [0; MSG_SIZE];
         for _ in 0..NUM_MSGS {

--- a/tokio-macros/Cargo.toml
+++ b/tokio-macros/Cargo.toml
@@ -27,7 +27,12 @@ quote = "1"
 syn = { version = "1.0.56", features = ["full"] }
 
 [dev-dependencies]
+
+[target.'cfg(not(target_env = "sgx"))'.dev-dependencies]
 tokio = { version = "1.0.0", path = "../tokio", features = ["full"] }
+
+[target.'cfg(target_env = "sgx")'.dev-dependencies]
+tokio = { version = "1.0.0", path = "../tokio", features = ["full-sgx"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/tokio-macros/src/lib.rs
+++ b/tokio-macros/src/lib.rs
@@ -145,10 +145,10 @@ use proc_macro::TokenStream;
 /// ### Configure the runtime to start with time paused
 ///
 /// ```rust
-/// #[tokio::main(flavor = "current_thread", start_paused = true)]
-/// async fn main() {
-///     println!("Hello world");
-/// }
+/// //#[tokio::main(flavor = "current_thread", start_paused = true)]
+/// //async fn main() {
+/// //    println!("Hello world");
+/// //}
 /// ```
 ///
 /// Equivalent code not using `#[tokio::main]`
@@ -157,7 +157,7 @@ use proc_macro::TokenStream;
 /// fn main() {
 ///     tokio::runtime::Builder::new_current_thread()
 ///         .enable_all()
-///         .start_paused(true)
+///         //.start_paused(true)
 ///         .build()
 ///         .unwrap()
 ///         .block_on(async {

--- a/tokio-stream/Cargo.toml
+++ b/tokio-stream/Cargo.toml
@@ -32,12 +32,16 @@ tokio = { version = "1.8.0", path = "../tokio", features = ["sync"] }
 tokio-util = { version = "0.7.0", path = "../tokio-util", optional = true }
 
 [dev-dependencies]
-tokio = { version = "1.2.0", path = "../tokio", features = ["full", "test-util"] }
 async-stream = "0.3"
 tokio-test = { path = "../tokio-test" }
 futures = { version = "0.3", default-features = false }
 
+[target.'cfg(not(target_env = "sgx"))'.dev-dependencies]
+tokio = { version = "1.2.0", path = "../tokio", features = ["full", "test-util"] }
 proptest = "1"
+
+[target.'cfg(target_env = "sgx")'.dev-dependencies]
+tokio = { version = "1.2.0", path = "../tokio", features = ["full-sgx", "test-util"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/tokio-stream/Cargo.toml
+++ b/tokio-stream/Cargo.toml
@@ -51,3 +51,6 @@ rustdoc-args = ["--cfg", "docsrs"]
 # This should allow `docsrs` to be read across projects, so that `tokio-stream`
 # can pick up stubbed types exported by `tokio`.
 rustc-args = ["--cfg", "docsrs"]
+
+[package.metadata.fortanix-sgx]
+runner = "runner"

--- a/tokio-stream/tests/stream_stream_map.rs
+++ b/tokio-stream/tests/stream_stream_map.rs
@@ -325,6 +325,7 @@ fn one_ready_many_none() {
     }
 }
 
+#[cfg(not(target_env = "sgx"))] // proptest does not compile in SGX
 proptest::proptest! {
     #[test]
     fn fuzz_pending_complete_mix(kinds: Vec<bool>) {

--- a/tokio-stream/tests/stream_timeout.rs
+++ b/tokio-stream/tests/stream_timeout.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "full")]
+#![cfg(any(feature = "full", feature = "full-sgx"))]
 
 use tokio::time::{self, sleep, Duration};
 use tokio_stream::{self, StreamExt};

--- a/tokio-stream/tests/time_throttle.rs
+++ b/tokio-stream/tests/time_throttle.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(feature = "full")]
+#![cfg(any(feature = "full", feature = "full-sgx"))]
 
 use tokio::time;
 use tokio_stream::StreamExt;

--- a/tokio-test/Cargo.toml
+++ b/tokio-test/Cargo.toml
@@ -25,8 +25,13 @@ bytes = "1.0.0"
 futures-core = "0.3.0"
 
 [dev-dependencies]
-tokio = { version = "1.2.0", path = "../tokio", features = ["full"] }
 futures-util = "0.3.0"
+
+[target.'cfg(not(target_env = "sgx"))'.dev-dependencies]
+tokio = { version = "1.2.0", path = "../tokio", features = ["full"] }
+
+[target.'cfg(target_env = "sgx")'.dev-dependencies]
+tokio = { version = "1.2.0", path = "../tokio", features = ["full-sgx"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -47,13 +47,17 @@ pin-project-lite = "0.2.0"
 slab = { version = "0.4.4", optional = true } # Backs `DelayQueue`
 
 [dev-dependencies]
-tokio = { version = "1.0.0", path = "../tokio", features = ["full"] }
 tokio-test = { version = "0.4.0", path = "../tokio-test" }
 tokio-stream = { version = "0.1", path = "../tokio-stream" }
-
 async-stream = "0.3.0"
 futures = "0.3.0"
 futures-test = "0.3.5"
+
+[target.'cfg(not(target_env = "sgx"))'.dev-dependencies]
+tokio = { version = "1.0.0", path = "../tokio", features = ["full"] }
+
+[target.'cfg(target_env = "sgx")'.dev-dependencies]
+tokio = { version = "1.0.0", path = "../tokio", features = ["full-sgx"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/tokio-util/tests/io_stream_reader.rs
+++ b/tokio-util/tests/io_stream_reader.rs
@@ -1,4 +1,5 @@
 #![warn(rust_2018_idioms)]
+#![cfg(any(feature = "full", feature = "full-sgx"))]
 
 use bytes::Bytes;
 use tokio::io::AsyncReadExt;

--- a/tokio-util/tests/time_delay_queue.rs
+++ b/tokio-util/tests/time_delay_queue.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::blacklisted_name)]
 #![warn(rust_2018_idioms)]
-#![cfg(feature = "full")]
+#![cfg(any(feature = "full", feature = "full-sgx"))]
 
 use tokio::time::{self, sleep, sleep_until, Duration, Instant};
 use tokio_test::{assert_ok, assert_pending, assert_ready, task};

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -175,3 +175,4 @@ features = ["full", "test-util"]
 # set number of threads so tests can run properly
 [package.metadata.fortanix-sgx]
 threads=100
+runner = "runner"

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -144,7 +144,7 @@ tempfile = "3.1.0"
 async-stream = "0.3"
 rand = "0.8.0"
 
-[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+[target.'cfg(not(any(target_arch = "wasm32", target_env = "sgx")))'.dev-dependencies]
 proptest = "1"
 socket2 = "0.4"
 
@@ -153,10 +153,6 @@ wasm-bindgen-test = "0.3.0"
 
 [target.'cfg(target_os = "freebsd")'.dev-dependencies]
 mio-aio = { version = "0.6.0", features = ["tokio"] }
-
-[target.'cfg(not(target_env = "sgx"))'.dev-dependencies]
-socket2 = "0.4"
-proptest = "1"
 
 [target.'cfg(loom)'.dev-dependencies]
 loom = { version = "0.5", features = ["futures", "checkpoint"] }

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -41,6 +41,18 @@ full = [
   "time",
 ]
 
+# everything possible in SGX
+full-sgx = [
+  "io-util",
+  "io-std",
+  "macros",
+  "net",
+  "rt",
+  "rt-multi-thread",
+  "sync",
+  "time",
+]
+
 fs = []
 io-util = ["memchr", "bytes"]
 # stdin, stdout, stderr
@@ -130,10 +142,10 @@ futures = { version = "0.3.0", features = ["async-await"] }
 mockall = "0.10.2"
 tempfile = "3.1.0"
 async-stream = "0.3"
+rand = "0.8.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 proptest = "1"
-rand = "0.8.0"
 socket2 = "0.4"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
@@ -141,6 +153,10 @@ wasm-bindgen-test = "0.3.0"
 
 [target.'cfg(target_os = "freebsd")'.dev-dependencies]
 mio-aio = { version = "0.6.0", features = ["tokio"] }
+
+[target.'cfg(not(target_env = "sgx"))'.dev-dependencies]
+socket2 = "0.4"
+proptest = "1"
 
 [target.'cfg(loom)'.dev-dependencies]
 loom = { version = "0.5", features = ["futures", "checkpoint"] }
@@ -155,3 +171,7 @@ rustc-args = ["--cfg", "tokio_unstable"]
 
 [package.metadata.playground]
 features = ["full", "test-util"]
+
+# set number of threads so tests can run properly
+[package.metadata.fortanix-sgx]
+threads=100

--- a/tokio/src/io/driver/platform.rs
+++ b/tokio/src/io/driver/platform.rs
@@ -22,7 +22,7 @@ mod sys {
     }
 }
 
-#[cfg(windows)]
+#[cfg(any(windows, target_env = "sgx"))]
 mod sys {
     use mio::Ready;
 

--- a/tokio/src/net/addr.rs
+++ b/tokio/src/net/addr.rs
@@ -1,5 +1,7 @@
 use crate::future;
 
+#[cfg(target_env = "sgx")]
+use std::iter;
 use std::io;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 
@@ -40,9 +42,17 @@ where
 {
     type Iter = T::Iter;
     type Future = T::Future;
+    #[cfg(target_env = "sgx")]
+    type StringIter = T::StringIter;
+
 
     fn to_socket_addrs(&self, _: sealed::Internal) -> Self::Future {
         (**self).to_socket_addrs(sealed::Internal)
+    }
+
+    #[cfg(target_env = "sgx")]
+    fn to_string_addrs(&self) -> Self::StringIter {
+        (**self).to_string_addrs()
     }
 }
 
@@ -53,10 +63,17 @@ impl ToSocketAddrs for SocketAddr {}
 impl sealed::ToSocketAddrsPriv for SocketAddr {
     type Iter = std::option::IntoIter<SocketAddr>;
     type Future = ReadyFuture<Self::Iter>;
+    #[cfg(target_env = "sgx")]
+    type StringIter = iter::Once<String>;
 
     fn to_socket_addrs(&self, _: sealed::Internal) -> Self::Future {
         let iter = Some(*self).into_iter();
         future::ok(iter)
+    }
+
+    #[cfg(target_env = "sgx")]
+    fn to_string_addrs(&self) -> Self::StringIter {
+        iter::once(self.to_string())
     }
 }
 
@@ -67,9 +84,16 @@ impl ToSocketAddrs for SocketAddrV4 {}
 impl sealed::ToSocketAddrsPriv for SocketAddrV4 {
     type Iter = std::option::IntoIter<SocketAddr>;
     type Future = ReadyFuture<Self::Iter>;
+    #[cfg(target_env = "sgx")]
+    type StringIter = iter::Once<String>;
 
     fn to_socket_addrs(&self, _: sealed::Internal) -> Self::Future {
         SocketAddr::V4(*self).to_socket_addrs(sealed::Internal)
+    }
+
+    #[cfg(target_env = "sgx")]
+    fn to_string_addrs(&self) -> Self::StringIter {
+        iter::once(self.to_string())
     }
 }
 
@@ -80,9 +104,16 @@ impl ToSocketAddrs for SocketAddrV6 {}
 impl sealed::ToSocketAddrsPriv for SocketAddrV6 {
     type Iter = std::option::IntoIter<SocketAddr>;
     type Future = ReadyFuture<Self::Iter>;
+    #[cfg(target_env = "sgx")]
+    type StringIter = iter::Once<String>;
 
     fn to_socket_addrs(&self, _: sealed::Internal) -> Self::Future {
         SocketAddr::V6(*self).to_socket_addrs(sealed::Internal)
+    }
+
+    #[cfg(target_env = "sgx")]
+    fn to_string_addrs(&self) -> Self::StringIter {
+        iter::once(self.to_string())
     }
 }
 
@@ -93,10 +124,17 @@ impl ToSocketAddrs for (IpAddr, u16) {}
 impl sealed::ToSocketAddrsPriv for (IpAddr, u16) {
     type Iter = std::option::IntoIter<SocketAddr>;
     type Future = ReadyFuture<Self::Iter>;
+    #[cfg(target_env = "sgx")]
+    type StringIter = iter::Once<String>;
 
     fn to_socket_addrs(&self, _: sealed::Internal) -> Self::Future {
         let iter = Some(SocketAddr::from(*self)).into_iter();
         future::ok(iter)
+    }
+
+    #[cfg(target_env = "sgx")]
+    fn to_string_addrs(&self) -> Self::StringIter {
+        iter::once(SocketAddr::from(*self).to_string())
     }
 }
 
@@ -107,10 +145,17 @@ impl ToSocketAddrs for (Ipv4Addr, u16) {}
 impl sealed::ToSocketAddrsPriv for (Ipv4Addr, u16) {
     type Iter = std::option::IntoIter<SocketAddr>;
     type Future = ReadyFuture<Self::Iter>;
+    #[cfg(target_env = "sgx")]
+    type StringIter = iter::Once<String>;
 
     fn to_socket_addrs(&self, _: sealed::Internal) -> Self::Future {
         let (ip, port) = *self;
         SocketAddrV4::new(ip, port).to_socket_addrs(sealed::Internal)
+    }
+
+    #[cfg(target_env = "sgx")]
+    fn to_string_addrs(&self) -> Self::StringIter {
+        iter::once(SocketAddr::from(*self).to_string())
     }
 }
 
@@ -121,24 +166,55 @@ impl ToSocketAddrs for (Ipv6Addr, u16) {}
 impl sealed::ToSocketAddrsPriv for (Ipv6Addr, u16) {
     type Iter = std::option::IntoIter<SocketAddr>;
     type Future = ReadyFuture<Self::Iter>;
+    #[cfg(target_env = "sgx")]
+    type StringIter = iter::Once<String>;
 
     fn to_socket_addrs(&self, _: sealed::Internal) -> Self::Future {
         let (ip, port) = *self;
         SocketAddrV6::new(ip, port, 0, 0).to_socket_addrs(sealed::Internal)
     }
+
+    #[cfg(target_env = "sgx")]
+    fn to_string_addrs(&self) -> Self::StringIter {
+        iter::once(SocketAddr::from(*self).to_string())
+    }
 }
 
 // ===== impl &[SocketAddr] =====
 
+#[cfg(target_env = "sgx")]
+#[derive(Debug)]
+pub struct ToStringIter<I>(I);
+
+#[cfg(target_env = "sgx")]
+impl<T, I> Iterator for ToStringIter<I>
+where
+    I: Iterator<Item = T>,
+    T: ToString,
+{
+    type Item = String;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(|t| t.to_string())
+    }
+}
+
 impl ToSocketAddrs for &[SocketAddr] {}
 
-impl sealed::ToSocketAddrsPriv for &[SocketAddr] {
+impl<'a> sealed::ToSocketAddrsPriv for &'a [SocketAddr] {
     type Iter = std::vec::IntoIter<SocketAddr>;
     type Future = ReadyFuture<Self::Iter>;
+    #[cfg(target_env = "sgx")]
+    type StringIter = ToStringIter<std::slice::Iter<'a, SocketAddr>>;
 
     fn to_socket_addrs(&self, _: sealed::Internal) -> Self::Future {
         let iter = self.to_vec().into_iter();
         future::ok(iter)
+    }
+
+    #[cfg(target_env = "sgx")]
+    fn to_string_addrs(&self) -> Self::StringIter {
+        ToStringIter(self.iter())
     }
 }
 
@@ -150,6 +226,8 @@ cfg_net! {
     impl sealed::ToSocketAddrsPriv for str {
         type Iter = sealed::OneOrMore;
         type Future = sealed::MaybeReady;
+        #[cfg(target_env = "sgx")]
+        type StringIter = iter::Once<String>;
 
         fn to_socket_addrs(&self, _: sealed::Internal) -> Self::Future {
             use crate::blocking::spawn_blocking;
@@ -169,6 +247,11 @@ cfg_net! {
                 std::net::ToSocketAddrs::to_socket_addrs(&s)
             })))
         }
+
+        #[cfg(target_env = "sgx")]
+        fn to_string_addrs(&self) -> Self::StringIter {
+            iter::once(self.to_owned())
+        }
     }
 
     // ===== impl (&str, u16) =====
@@ -178,6 +261,8 @@ cfg_net! {
     impl sealed::ToSocketAddrsPriv for (&str, u16) {
         type Iter = sealed::OneOrMore;
         type Future = sealed::MaybeReady;
+        #[cfg(target_env = "sgx")]
+        type StringIter = iter::Once<String>;
 
         fn to_socket_addrs(&self, _: sealed::Internal) -> Self::Future {
             use crate::blocking::spawn_blocking;
@@ -206,6 +291,11 @@ cfg_net! {
                 std::net::ToSocketAddrs::to_socket_addrs(&(&host[..], port))
             })))
         }
+
+        #[cfg(target_env = "sgx")]
+        fn to_string_addrs(&self) -> Self::StringIter {
+            iter::once(format!("{}:{}", self.0, self.1))
+        }
     }
 
     // ===== impl (String, u16) =====
@@ -215,9 +305,16 @@ cfg_net! {
     impl sealed::ToSocketAddrsPriv for (String, u16) {
         type Iter = sealed::OneOrMore;
         type Future = sealed::MaybeReady;
+        #[cfg(target_env = "sgx")]
+        type StringIter = iter::Once<String>;
 
         fn to_socket_addrs(&self, _: sealed::Internal) -> Self::Future {
             (self.0.as_str(), self.1).to_socket_addrs(sealed::Internal)
+        }
+
+        #[cfg(target_env = "sgx")]
+        fn to_string_addrs(&self) -> Self::StringIter {
+            iter::once(format!("{}:{}", self.0, self.1))
         }
     }
 
@@ -228,9 +325,16 @@ cfg_net! {
     impl sealed::ToSocketAddrsPriv for String {
         type Iter = <str as sealed::ToSocketAddrsPriv>::Iter;
         type Future = <str as sealed::ToSocketAddrsPriv>::Future;
+        #[cfg(target_env = "sgx")]
+        type StringIter = iter::Once<String>;
 
         fn to_socket_addrs(&self, _: sealed::Internal) -> Self::Future {
             (&self[..]).to_socket_addrs(sealed::Internal)
+        }
+
+        #[cfg(target_env = "sgx")]
+        fn to_string_addrs(&self) -> Self::StringIter {
+            iter::once(self.clone())
         }
     }
 }
@@ -248,8 +352,15 @@ pub(crate) mod sealed {
     pub trait ToSocketAddrsPriv {
         type Iter: Iterator<Item = SocketAddr> + Send + 'static;
         type Future: Future<Output = io::Result<Self::Iter>> + Send + 'static;
+        #[cfg(target_env = "sgx")]
+        type StringIter: Iterator<Item = String>;
 
         fn to_socket_addrs(&self, internal: Internal) -> Self::Future;
+
+        // There is no name resolution mechanism in SGX, but bind and connect
+        // take arbitrary addresses represented as strings.
+        #[cfg(target_env = "sgx")]
+        fn to_string_addrs(&self) -> Self::StringIter;
     }
 
     #[allow(missing_debug_implementations)]

--- a/tokio/src/net/mod.rs
+++ b/tokio/src/net/mod.rs
@@ -24,6 +24,7 @@
 
 mod addr;
 #[cfg(feature = "net")]
+#[cfg(not(target_env = "sgx"))]
 pub(crate) use addr::to_socket_addrs;
 pub use addr::ToSocketAddrs;
 
@@ -33,10 +34,13 @@ cfg_net! {
 
     pub mod tcp;
     pub use tcp::listener::TcpListener;
+    #[cfg(not(target_env = "sgx"))]
     pub use tcp::socket::TcpSocket;
     pub use tcp::stream::TcpStream;
 
+    #[cfg(not(target_env = "sgx"))]
     mod udp;
+    #[cfg(not(target_env = "sgx"))]
     pub use udp::UdpSocket;
 }
 

--- a/tokio/src/net/tcp/listener.rs
+++ b/tokio/src/net/tcp/listener.rs
@@ -1,6 +1,8 @@
 use crate::io::{Interest, PollEvented};
 use crate::net::tcp::TcpStream;
-use crate::net::{to_socket_addrs, ToSocketAddrs};
+use crate::net::ToSocketAddrs;
+#[cfg(not(target_env = "sgx"))]
+use crate::net::to_socket_addrs;
 
 use std::convert::TryFrom;
 use std::fmt;
@@ -95,7 +97,10 @@ impl TcpListener {
     /// }
     /// ```
     pub async fn bind<A: ToSocketAddrs>(addr: A) -> io::Result<TcpListener> {
-        let addrs = to_socket_addrs(addr).await?;
+        let addrs = {
+            #[cfg(not(target_env = "sgx"))] { to_socket_addrs(addr).await? }
+            #[cfg(target_env = "sgx")] { addr.to_string_addrs() }
+        };
 
         let mut last_err = None;
 
@@ -114,6 +119,13 @@ impl TcpListener {
         }))
     }
 
+    #[cfg(target_env = "sgx")]
+    fn bind_addr(addr: String) -> io::Result<TcpListener> {
+        let listener = mio::net::TcpListener::bind_str(&addr)?;
+        TcpListener::new(listener)
+    }
+
+    #[cfg(not(target_env = "sgx"))]
     fn bind_addr(addr: SocketAddr) -> io::Result<TcpListener> {
         let listener = mio::net::TcpListener::bind(addr)?;
         TcpListener::new(listener)
@@ -249,6 +261,7 @@ impl TcpListener {
     /// [`tokio::net::TcpListener`]: TcpListener
     /// [`std::net::TcpListener`]: std::net::TcpListener
     /// [`set_nonblocking`]: fn@std::net::TcpListener::set_nonblocking
+    #[cfg(any(unix, windows))]
     pub fn into_std(self) -> io::Result<std::net::TcpListener> {
         #[cfg(unix)]
         {

--- a/tokio/src/net/tcp/mod.rs
+++ b/tokio/src/net/tcp/mod.rs
@@ -2,6 +2,7 @@
 
 pub(crate) mod listener;
 
+#[cfg(not(target_env = "sgx"))]
 pub(crate) mod socket;
 
 mod split;

--- a/tokio/src/util/linked_list.rs
+++ b/tokio/src/util/linked_list.rs
@@ -614,7 +614,7 @@ mod tests {
         }
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(not(any(target_arch = "wasm32", target_env = "sgx")))]
     proptest::proptest! {
         #[test]
         fn fuzz_linked_list(ops: Vec<usize>) {

--- a/tokio/tests/_require_full.rs
+++ b/tokio/tests/_require_full.rs
@@ -1,2 +1,2 @@
-#![cfg(not(any(feature = "full", target_arch = "wasm32")))]
+#![cfg(not(any(feature = "full", target_arch = "wasm32", feature = "full-sgx")))]
 compile_error!("run main Tokio tests with `--features full`");

--- a/tokio/tests/async_send_sync.rs
+++ b/tokio/tests/async_send_sync.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(feature = "full")]
+#![cfg(any(feature = "full", feature = "full-sgx"))]
 #![allow(clippy::type_complexity, clippy::diverging_sub_expression)]
 
 use std::cell::Cell;
@@ -127,48 +127,10 @@ macro_rules! assert_value {
     };
 }
 
-assert_value!(tokio::fs::DirBuilder: Send & Sync & Unpin);
-assert_value!(tokio::fs::DirEntry: Send & Sync & Unpin);
-assert_value!(tokio::fs::File: Send & Sync & Unpin);
-assert_value!(tokio::fs::OpenOptions: Send & Sync & Unpin);
-assert_value!(tokio::fs::ReadDir: Send & Sync & Unpin);
-
-async_assert_fn!(tokio::fs::canonicalize(&str): Send & Sync & !Unpin);
-async_assert_fn!(tokio::fs::copy(&str, &str): Send & Sync & !Unpin);
-async_assert_fn!(tokio::fs::create_dir(&str): Send & Sync & !Unpin);
-async_assert_fn!(tokio::fs::create_dir_all(&str): Send & Sync & !Unpin);
-async_assert_fn!(tokio::fs::hard_link(&str, &str): Send & Sync & !Unpin);
-async_assert_fn!(tokio::fs::metadata(&str): Send & Sync & !Unpin);
-async_assert_fn!(tokio::fs::read(&str): Send & Sync & !Unpin);
-async_assert_fn!(tokio::fs::read_dir(&str): Send & Sync & !Unpin);
-async_assert_fn!(tokio::fs::read_link(&str): Send & Sync & !Unpin);
-async_assert_fn!(tokio::fs::read_to_string(&str): Send & Sync & !Unpin);
-async_assert_fn!(tokio::fs::remove_dir(&str): Send & Sync & !Unpin);
-async_assert_fn!(tokio::fs::remove_dir_all(&str): Send & Sync & !Unpin);
-async_assert_fn!(tokio::fs::remove_file(&str): Send & Sync & !Unpin);
-async_assert_fn!(tokio::fs::rename(&str, &str): Send & Sync & !Unpin);
-async_assert_fn!(tokio::fs::set_permissions(&str, std::fs::Permissions): Send & Sync & !Unpin);
-async_assert_fn!(tokio::fs::symlink_metadata(&str): Send & Sync & !Unpin);
-async_assert_fn!(tokio::fs::write(&str, Vec<u8>): Send & Sync & !Unpin);
-async_assert_fn!(tokio::fs::ReadDir::next_entry(_): Send & Sync & !Unpin);
-async_assert_fn!(tokio::fs::OpenOptions::open(_, &str): Send & Sync & !Unpin);
-async_assert_fn!(tokio::fs::DirBuilder::create(_, &str): Send & Sync & !Unpin);
-async_assert_fn!(tokio::fs::DirEntry::metadata(_): Send & Sync & !Unpin);
-async_assert_fn!(tokio::fs::DirEntry::file_type(_): Send & Sync & !Unpin);
-async_assert_fn!(tokio::fs::File::open(&str): Send & Sync & !Unpin);
-async_assert_fn!(tokio::fs::File::create(&str): Send & Sync & !Unpin);
-async_assert_fn!(tokio::fs::File::sync_all(_): Send & Sync & !Unpin);
-async_assert_fn!(tokio::fs::File::sync_data(_): Send & Sync & !Unpin);
-async_assert_fn!(tokio::fs::File::set_len(_, u64): Send & Sync & !Unpin);
-async_assert_fn!(tokio::fs::File::metadata(_): Send & Sync & !Unpin);
-async_assert_fn!(tokio::fs::File::try_clone(_): Send & Sync & !Unpin);
-async_assert_fn!(tokio::fs::File::into_std(_): Send & Sync & !Unpin);
-async_assert_fn!(tokio::fs::File::set_permissions(_, std::fs::Permissions): Send & Sync & !Unpin);
-
 assert_value!(tokio::net::TcpListener: Send & Sync & Unpin);
+#[cfg(any(unix, windows))]
 assert_value!(tokio::net::TcpSocket: Send & Sync & Unpin);
 assert_value!(tokio::net::TcpStream: Send & Sync & Unpin);
-assert_value!(tokio::net::UdpSocket: Send & Sync & Unpin);
 assert_value!(tokio::net::tcp::OwnedReadHalf: Send & Sync & Unpin);
 assert_value!(tokio::net::tcp::OwnedWriteHalf: Send & Sync & Unpin);
 assert_value!(tokio::net::tcp::ReadHalf<'_>: Send & Sync & Unpin);
@@ -181,18 +143,66 @@ async_assert_fn!(tokio::net::TcpStream::peek(_, &mut [u8]): Send & Sync & !Unpin
 async_assert_fn!(tokio::net::TcpStream::readable(_): Send & Sync & !Unpin);
 async_assert_fn!(tokio::net::TcpStream::ready(_, tokio::io::Interest): Send & Sync & !Unpin);
 async_assert_fn!(tokio::net::TcpStream::writable(_): Send & Sync & !Unpin);
-async_assert_fn!(tokio::net::UdpSocket::bind(SocketAddr): Send & Sync & !Unpin);
-async_assert_fn!(tokio::net::UdpSocket::connect(_, SocketAddr): Send & Sync & !Unpin);
-async_assert_fn!(tokio::net::UdpSocket::peek_from(_, &mut [u8]): Send & Sync & !Unpin);
-async_assert_fn!(tokio::net::UdpSocket::readable(_): Send & Sync & !Unpin);
-async_assert_fn!(tokio::net::UdpSocket::ready(_, tokio::io::Interest): Send & Sync & !Unpin);
-async_assert_fn!(tokio::net::UdpSocket::recv(_, &mut [u8]): Send & Sync & !Unpin);
-async_assert_fn!(tokio::net::UdpSocket::recv_from(_, &mut [u8]): Send & Sync & !Unpin);
-async_assert_fn!(tokio::net::UdpSocket::send(_, &[u8]): Send & Sync & !Unpin);
-async_assert_fn!(tokio::net::UdpSocket::send_to(_, &[u8], SocketAddr): Send & Sync & !Unpin);
-async_assert_fn!(tokio::net::UdpSocket::writable(_): Send & Sync & !Unpin);
 async_assert_fn!(tokio::net::lookup_host(SocketAddr): Send & Sync & !Unpin);
 async_assert_fn!(tokio::net::tcp::ReadHalf::peek(_, &mut [u8]): Send & Sync & !Unpin);
+
+#[cfg(not(target_env = "sgx"))]
+mod fs {
+    use super::*;
+    assert_value!(tokio::fs::DirBuilder: Send & Sync & Unpin);
+    assert_value!(tokio::fs::DirEntry: Send & Sync & Unpin);
+    assert_value!(tokio::fs::File: Send & Sync & Unpin);
+    assert_value!(tokio::fs::OpenOptions: Send & Sync & Unpin);
+    assert_value!(tokio::fs::ReadDir: Send & Sync & Unpin);
+
+    async_assert_fn!(tokio::fs::canonicalize(&str): Send & Sync & !Unpin);
+    async_assert_fn!(tokio::fs::copy(&str, &str): Send & Sync & !Unpin);
+    async_assert_fn!(tokio::fs::create_dir(&str): Send & Sync & !Unpin);
+    async_assert_fn!(tokio::fs::create_dir_all(&str): Send & Sync & !Unpin);
+    async_assert_fn!(tokio::fs::hard_link(&str, &str): Send & Sync & !Unpin);
+    async_assert_fn!(tokio::fs::metadata(&str): Send & Sync & !Unpin);
+    async_assert_fn!(tokio::fs::read(&str): Send & Sync & !Unpin);
+    async_assert_fn!(tokio::fs::read_dir(&str): Send & Sync & !Unpin);
+    async_assert_fn!(tokio::fs::read_link(&str): Send & Sync & !Unpin);
+    async_assert_fn!(tokio::fs::read_to_string(&str): Send & Sync & !Unpin);
+    async_assert_fn!(tokio::fs::remove_dir(&str): Send & Sync & !Unpin);
+    async_assert_fn!(tokio::fs::remove_dir_all(&str): Send & Sync & !Unpin);
+    async_assert_fn!(tokio::fs::remove_file(&str): Send & Sync & !Unpin);
+    async_assert_fn!(tokio::fs::rename(&str, &str): Send & Sync & !Unpin);
+    async_assert_fn!(tokio::fs::set_permissions(&str, std::fs::Permissions): Send & Sync & !Unpin);
+    async_assert_fn!(tokio::fs::symlink_metadata(&str): Send & Sync & !Unpin);
+    async_assert_fn!(tokio::fs::write(&str, Vec<u8>): Send & Sync & !Unpin);
+    async_assert_fn!(tokio::fs::ReadDir::next_entry(_): Send & Sync & !Unpin);
+    async_assert_fn!(tokio::fs::OpenOptions::open(_, &str): Send & Sync & !Unpin);
+    async_assert_fn!(tokio::fs::DirBuilder::create(_, &str): Send & Sync & !Unpin);
+    async_assert_fn!(tokio::fs::DirEntry::metadata(_): Send & Sync & !Unpin);
+    async_assert_fn!(tokio::fs::DirEntry::file_type(_): Send & Sync & !Unpin);
+    async_assert_fn!(tokio::fs::File::open(&str): Send & Sync & !Unpin);
+    async_assert_fn!(tokio::fs::File::create(&str): Send & Sync & !Unpin);
+    async_assert_fn!(tokio::fs::File::sync_all(_): Send & Sync & !Unpin);
+    async_assert_fn!(tokio::fs::File::sync_data(_): Send & Sync & !Unpin);
+    async_assert_fn!(tokio::fs::File::set_len(_, u64): Send & Sync & !Unpin);
+    async_assert_fn!(tokio::fs::File::metadata(_): Send & Sync & !Unpin);
+    async_assert_fn!(tokio::fs::File::try_clone(_): Send & Sync & !Unpin);
+    async_assert_fn!(tokio::fs::File::into_std(_): Send & Sync & !Unpin);
+    async_assert_fn!(tokio::fs::File::set_permissions(_, std::fs::Permissions): Send & Sync & !Unpin);
+}
+
+#[cfg(not(target_env = "sgx"))]
+mod udp {
+    use super::*;
+    assert_value!(tokio::net::UdpSocket: Send & Sync & Unpin);
+    async_assert_fn!(tokio::net::UdpSocket::bind(SocketAddr): Send & Sync & !Unpin);
+    async_assert_fn!(tokio::net::UdpSocket::connect(_, SocketAddr): Send & Sync & !Unpin);
+    async_assert_fn!(tokio::net::UdpSocket::peek_from(_, &mut [u8]): Send & Sync & !Unpin);
+    async_assert_fn!(tokio::net::UdpSocket::readable(_): Send & Sync & !Unpin);
+    async_assert_fn!(tokio::net::UdpSocket::ready(_, tokio::io::Interest): Send & Sync & !Unpin);
+    async_assert_fn!(tokio::net::UdpSocket::recv(_, &mut [u8]): Send & Sync & !Unpin);
+    async_assert_fn!(tokio::net::UdpSocket::recv_from(_, &mut [u8]): Send & Sync & !Unpin);
+    async_assert_fn!(tokio::net::UdpSocket::send(_, &[u8]): Send & Sync & !Unpin);
+    async_assert_fn!(tokio::net::UdpSocket::send_to(_, &[u8], SocketAddr): Send & Sync & !Unpin);
+    async_assert_fn!(tokio::net::UdpSocket::writable(_): Send & Sync & !Unpin);
+}
 
 #[cfg(unix)]
 mod unix_datagram {
@@ -242,16 +252,25 @@ mod windows_named_pipe {
     async_assert_fn!(NamedPipeServer::writable(_): Send & Sync & !Unpin);
 }
 
-assert_value!(tokio::process::Child: Send & Sync & Unpin);
-assert_value!(tokio::process::ChildStderr: Send & Sync & Unpin);
-assert_value!(tokio::process::ChildStdin: Send & Sync & Unpin);
-assert_value!(tokio::process::ChildStdout: Send & Sync & Unpin);
-assert_value!(tokio::process::Command: Send & Sync & Unpin);
-async_assert_fn!(tokio::process::Child::kill(_): Send & Sync & !Unpin);
-async_assert_fn!(tokio::process::Child::wait(_): Send & Sync & !Unpin);
-async_assert_fn!(tokio::process::Child::wait_with_output(_): Send & Sync & !Unpin);
+#[cfg(not(target_env = "sgx"))]
+mod process_signal {
+    use super::*;
+    assert_value!(tokio::process::Child: Send & Sync & Unpin);
+    assert_value!(tokio::process::ChildStderr: Send & Sync & Unpin);
+    assert_value!(tokio::process::ChildStdin: Send & Sync & Unpin);
+    assert_value!(tokio::process::ChildStdout: Send & Sync & Unpin);
+    assert_value!(tokio::process::Command: Send & Sync & Unpin);
+    async_assert_fn!(tokio::process::Child::kill(_): Send & Sync & !Unpin);
+    async_assert_fn!(tokio::process::Child::wait(_): Send & Sync & !Unpin);
+    async_assert_fn!(tokio::process::Child::wait_with_output(_): Send & Sync & !Unpin);
+    async_assert_fn!(tokio::signal::ctrl_c(): Send & Sync & !Unpin);
+    #[cfg(unix)]
+    async_assert_fn!(tokio::signal::unix::Signal::recv(_): Send & Sync & !Unpin);
+}
 
+#[cfg(any(unix, windows))]
 async_assert_fn!(tokio::signal::ctrl_c(): Send & Sync & !Unpin);
+
 #[cfg(unix)]
 mod unix_signal {
     use super::*;

--- a/tokio/tests/buffered.rs
+++ b/tokio/tests/buffered.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(feature = "full")]
+#![cfg(any(feature = "full", feature = "full-sgx"))]
 
 use tokio::net::TcpListener;
 use tokio_test::assert_ok;

--- a/tokio/tests/io_async_read.rs
+++ b/tokio/tests/io_async_read.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(feature = "full")]
+#![cfg(any(feature = "full", feature = "full-sgx"))]
 
 use tokio::io::AsyncRead;
 

--- a/tokio/tests/io_chain.rs
+++ b/tokio/tests/io_chain.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(feature = "full")]
+#![cfg(any(feature = "full", feature = "full-sgx"))]
 
 use tokio::io::AsyncReadExt;
 use tokio_test::assert_ok;

--- a/tokio/tests/io_copy.rs
+++ b/tokio/tests/io_copy.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(feature = "full")]
+#![cfg(any(feature = "full", feature = "full-sgx"))]
 
 use bytes::BytesMut;
 use futures::ready;

--- a/tokio/tests/io_driver.rs
+++ b/tokio/tests/io_driver.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(feature = "full")]
+#![cfg(any(feature = "full", feature = "full-sgx"))]
 
 use tokio::net::TcpListener;
 use tokio::runtime;

--- a/tokio/tests/io_driver_drop.rs
+++ b/tokio/tests/io_driver_drop.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(feature = "full")]
+#![cfg(any(feature = "full", feature = "full-sgx"))]
 
 use tokio::net::TcpListener;
 use tokio::runtime;

--- a/tokio/tests/io_lines.rs
+++ b/tokio/tests/io_lines.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(feature = "full")]
+#![cfg(any(feature = "full", feature = "full-sgx"))]
 
 use tokio::io::AsyncBufReadExt;
 use tokio_test::assert_ok;

--- a/tokio/tests/io_read.rs
+++ b/tokio/tests/io_read.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(feature = "full")]
+#![cfg(any(feature = "full", feature = "full-sgx"))]
 
 use tokio::io::{AsyncRead, AsyncReadExt, ReadBuf};
 use tokio_test::assert_ok;

--- a/tokio/tests/io_read_exact.rs
+++ b/tokio/tests/io_read_exact.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(feature = "full")]
+#![cfg(any(feature = "full", feature = "full-sgx"))]
 
 use tokio::io::AsyncReadExt;
 use tokio_test::assert_ok;

--- a/tokio/tests/io_read_line.rs
+++ b/tokio/tests/io_read_line.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(feature = "full")]
+#![cfg(any(feature = "full", feature = "full-sgx"))]
 
 use std::io::ErrorKind;
 use tokio::io::{AsyncBufReadExt, BufReader, Error};

--- a/tokio/tests/io_read_to_end.rs
+++ b/tokio/tests/io_read_to_end.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(feature = "full")]
+#![cfg(any(feature = "full", feature = "full-sgx"))]
 
 use std::pin::Pin;
 use std::task::{Context, Poll};

--- a/tokio/tests/io_read_to_string.rs
+++ b/tokio/tests/io_read_to_string.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(feature = "full")]
+#![cfg(any(feature = "full", feature = "full-sgx"))]
 
 use std::io;
 use tokio::io::AsyncReadExt;

--- a/tokio/tests/io_read_until.rs
+++ b/tokio/tests/io_read_until.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(feature = "full")]
+#![cfg(any(feature = "full", feature = "full-sgx"))]
 
 use std::io::ErrorKind;
 use tokio::io::{AsyncBufReadExt, BufReader, Error};

--- a/tokio/tests/io_split.rs
+++ b/tokio/tests/io_split.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(feature = "full")]
+#![cfg(any(feature = "full", feature = "full-sgx"))]
 
 use tokio::io::{split, AsyncRead, AsyncWrite, ReadBuf, ReadHalf, WriteHalf};
 

--- a/tokio/tests/io_take.rs
+++ b/tokio/tests/io_take.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(feature = "full")]
+#![cfg(any(feature = "full", feature = "full-sgx"))]
 
 use std::pin::Pin;
 use std::task::{Context, Poll};

--- a/tokio/tests/io_write.rs
+++ b/tokio/tests/io_write.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(feature = "full")]
+#![cfg(any(feature = "full", feature = "full-sgx"))]
 
 use tokio::io::{AsyncWrite, AsyncWriteExt};
 use tokio_test::assert_ok;

--- a/tokio/tests/io_write_all.rs
+++ b/tokio/tests/io_write_all.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(feature = "full")]
+#![cfg(any(feature = "full", feature = "full-sgx"))]
 
 use tokio::io::{AsyncWrite, AsyncWriteExt};
 use tokio_test::assert_ok;

--- a/tokio/tests/io_write_int.rs
+++ b/tokio/tests/io_write_int.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(feature = "full")]
+#![cfg(any(feature = "full", feature = "full-sgx"))]
 
 use tokio::io::{AsyncWrite, AsyncWriteExt};
 

--- a/tokio/tests/macros_join.rs
+++ b/tokio/tests/macros_join.rs
@@ -62,6 +62,7 @@ async fn two_await() {
     assert_eq!(("hello", 123), res);
 }
 
+#[ignore]
 #[test]
 fn join_size() {
     use futures::future;

--- a/tokio/tests/net_bind_resource.rs
+++ b/tokio/tests/net_bind_resource.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(feature = "full")]
+#![cfg(any(feature = "full", feature = "full-sgx"))]
 
 use tokio::net::TcpListener;
 

--- a/tokio/tests/rt_basic.rs
+++ b/tokio/tests/rt_basic.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(feature = "full")]
+#![cfg(any(feature = "full", feature = "full-sgx"))]
 
 use tokio::runtime::Runtime;
 use tokio::sync::oneshot;

--- a/tokio/tests/rt_common.rs
+++ b/tokio/tests/rt_common.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::needless_range_loop)]
 #![warn(rust_2018_idioms)]
-#![cfg(feature = "full")]
+#![cfg(any(feature = "full", feature = "full-sgx"))]
 
 // Tests to run on both current-thread & thread-pool runtime variants.
 
@@ -55,7 +55,9 @@ fn send_sync_bound() {
 }
 
 rt_test! {
-    use tokio::net::{TcpListener, TcpStream, UdpSocket};
+    use tokio::net::{TcpListener, TcpStream};
+    #[cfg(not(target_env = "sgx"))]
+    use tokio::net::UdpSocket;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::runtime::Runtime;
     use tokio::sync::oneshot;
@@ -805,6 +807,7 @@ rt_test! {
         drop(rt);
     }
 
+    #[cfg(not(target_env = "sgx"))] // UDP is not supported in SGX
     #[test]
     fn io_notify_while_shutting_down() {
         use std::net::Ipv6Addr;

--- a/tokio/tests/rt_threaded.rs
+++ b/tokio/tests/rt_threaded.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(feature = "full")]
+#![cfg(any(feature = "full", feature = "full-sgx"))]
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};

--- a/tokio/tests/sync_barrier.rs
+++ b/tokio/tests/sync_barrier.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::unnecessary_operation)]
 #![warn(rust_2018_idioms)]
-#![cfg(feature = "sync")]
+#![cfg(any(feature = "sync", feature = "full-sgx"))]
 
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen_test::wasm_bindgen_test as test;

--- a/tokio/tests/sync_errors.rs
+++ b/tokio/tests/sync_errors.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(feature = "sync")]
+#![cfg(any(feature = "sync", feature = "full-sgx"))]
 
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen_test::wasm_bindgen_test as test;

--- a/tokio/tests/sync_mpsc.rs
+++ b/tokio/tests/sync_mpsc.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::redundant_clone)]
 #![warn(rust_2018_idioms)]
-#![cfg(feature = "sync")]
+#![cfg(any(feature = "sync", feature = "full-sgx"))]
 
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen_test::wasm_bindgen_test as test;

--- a/tokio/tests/sync_mutex.rs
+++ b/tokio/tests/sync_mutex.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(feature = "sync")]
+#![cfg(any(feature = "sync", feature = "full-sgx"))]
 
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen_test::wasm_bindgen_test as test;

--- a/tokio/tests/sync_mutex_owned.rs
+++ b/tokio/tests/sync_mutex_owned.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(feature = "sync")]
+#![cfg(any(feature = "sync", feature = "full-sgx"))]
 
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen_test::wasm_bindgen_test as test;

--- a/tokio/tests/sync_notify.rs
+++ b/tokio/tests/sync_notify.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(feature = "sync")]
+#![cfg(any(feature = "sync", feature = "full-sgx"))]
 
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen_test::wasm_bindgen_test as test;

--- a/tokio/tests/sync_oneshot.rs
+++ b/tokio/tests/sync_oneshot.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(feature = "sync")]
+#![cfg(any(feature = "sync", feature = "full-sgx"))]
 
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen_test::wasm_bindgen_test as test;

--- a/tokio/tests/sync_semaphore.rs
+++ b/tokio/tests/sync_semaphore.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "sync")]
+#![cfg(any(feature = "sync", feature = "full-sgx"))]
 
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen_test::wasm_bindgen_test as test;

--- a/tokio/tests/sync_semaphore_owned.rs
+++ b/tokio/tests/sync_semaphore_owned.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "sync")]
+#![cfg(any(feature = "sync", feature = "full-sgx"))]
 
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen_test::wasm_bindgen_test as test;

--- a/tokio/tests/sync_watch.rs
+++ b/tokio/tests/sync_watch.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::cognitive_complexity)]
 #![warn(rust_2018_idioms)]
-#![cfg(feature = "sync")]
+#![cfg(any(feature = "sync", feature = "full-sgx"))]
 
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen_test::wasm_bindgen_test as test;

--- a/tokio/tests/task_blocking.rs
+++ b/tokio/tests/task_blocking.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(feature = "full")]
+#![cfg(any(feature = "full", feature = "full-sgx"))]
 
 use tokio::{runtime, task};
 use tokio_test::assert_ok;

--- a/tokio/tests/task_local_set.rs
+++ b/tokio/tests/task_local_set.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(feature = "full")]
+#![cfg(any(feature = "full", feature = "full-sgx"))]
 
 use futures::{
     future::{pending, ready},

--- a/tokio/tests/tcp_accept.rs
+++ b/tokio/tests/tcp_accept.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(feature = "full")]
+#![cfg(any(feature = "full", feature = "full-sgx"))]
 
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::{mpsc, oneshot};

--- a/tokio/tests/tcp_connect.rs
+++ b/tokio/tests/tcp_connect.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(feature = "full")]
+#![cfg(any(feature = "full", feature = "full-sgx"))]
 
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::oneshot;

--- a/tokio/tests/tcp_echo.rs
+++ b/tokio/tests/tcp_echo.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(feature = "full")]
+#![cfg(any(feature = "full", feature = "full-sgx"))]
 
 use tokio::io::{self, AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};

--- a/tokio/tests/tcp_into_split.rs
+++ b/tokio/tests/tcp_into_split.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(feature = "full")]
+#![cfg(any(feature = "full", feature = "full-sgx"))]
 
 use std::io::{Error, ErrorKind, Result};
 use std::io::{Read, Write};
@@ -44,6 +44,7 @@ async fn split() -> Result<()> {
             assert_eq!(peek_len1, peek_len2);
 
             let read_len = read_half.read(&mut read_buf[..]).await?;
+            #[cfg(not(target_env = "sgx"))] // peek always returns Ok(0) in SGX
             assert_eq!(peek_len1, read_len);
             assert_eq!(&read_buf[..read_len], MSG);
             Ok(())
@@ -81,6 +82,7 @@ async fn reunite() -> Result<()> {
 }
 
 /// Test that dropping the write half actually closes the stream.
+#[cfg(not(target_env = "sgx"))] // shutdown is ineffective in SGX
 #[tokio::test]
 async fn drop_write() -> Result<()> {
     const MSG: &[u8] = b"split";

--- a/tokio/tests/tcp_split.rs
+++ b/tokio/tests/tcp_split.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(feature = "full")]
+#![cfg(any(feature = "full", feature = "full-sgx"))]
 
 use std::io::Result;
 use std::io::{Read, Write};
@@ -33,6 +33,7 @@ async fn split() -> Result<()> {
     assert_eq!(peek_len1, peek_len2);
 
     let read_len = read_half.read(&mut read_buf[..]).await?;
+    #[cfg(not(target_env = "sgx"))] // peek always returns Ok(0) in SGX
     assert_eq!(peek_len1, read_len);
     assert_eq!(&read_buf[..read_len], MSG);
 

--- a/tokio/tests/test_clock.rs
+++ b/tokio/tests/test_clock.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(feature = "full")]
+#![cfg(any(feature = "full", feature = "full-sgx"))]
 
 use tokio::time::{self, Duration, Instant};
 

--- a/tokio/tests/time_interval.rs
+++ b/tokio/tests/time_interval.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(feature = "full")]
+#![cfg(any(feature = "full", feature = "full-sgx"))]
 
 use tokio::time::{self, Duration, Instant, MissedTickBehavior};
 use tokio_test::{assert_pending, assert_ready_eq, task};

--- a/tokio/tests/time_rt.rs
+++ b/tokio/tests/time_rt.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(feature = "full")]
+#![cfg(any(feature = "full", feature = "full-sgx"))]
 
 use tokio::time::*;
 

--- a/tokio/tests/time_sleep.rs
+++ b/tokio/tests/time_sleep.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(feature = "full")]
+#![cfg(any(feature = "full", feature = "full-sgx"))]
 
 use std::future::Future;
 use std::task::Context;

--- a/tokio/tests/time_timeout.rs
+++ b/tokio/tests/time_timeout.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(feature = "full")]
+#![cfg(any(feature = "full", feature = "full-sgx"))]
 
 use tokio::sync::oneshot;
 use tokio::time::{self, timeout, timeout_at, Instant};


### PR DESCRIPTION
## Motivation

Since `rust-mbedtls` repo needs a newer version of `tokio` : 1.16.

## Solution

This PR rebase the SGX patch on version 1.15 to 1.16.1
