### PR TITLE
Support fortanixvme

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -111,7 +111,7 @@ mio = { version = "0.8.10", optional = true, default-features = false }
 num_cpus = { version = "1.8.0", optional = true }
 parking_lot = { version = "0.12.0", optional = true }
 
-[target.'cfg(not(any(target_family = "wasm", target_env = "sgx")))'.dependencies]
+[target.'cfg(not(any(target_family = "wasm", target_env = "sgx", target_env = "fortanixvme")))'.dependencies]
 socket2 = { version = "0.5.5", optional = true, features = [ "all" ] }
 
 # Currently unstable. The API exposed by these features may be broken at any time.
@@ -150,7 +150,7 @@ futures = { version = "0.3.0", features = ["async-await"] }
 mockall = "0.11.1"
 async-stream = "0.3"
 
-[target.'cfg(not(any(target_family = "wasm", target_env = "sgx")))'.dev-dependencies]
+[target.'cfg(not(any(target_family = "wasm", target_env = "sgx", target_env = "fortanixvme")))'.dev-dependencies]
 socket2 = "0.5.5"
 tempfile = "3.1.0"
 

--- a/tokio/src/macros/cfg.rs
+++ b/tokio/src/macros/cfg.rs
@@ -265,7 +265,7 @@ macro_rules! cfg_net {
 macro_rules! cfg_net_unix {
     ($($item:item)*) => {
         $(
-            #[cfg(all(unix, feature = "net"))]
+            #[cfg(all(unix, feature = "net", not(target_env = "fortanixvme")))]
             #[cfg_attr(docsrs, doc(cfg(all(unix, feature = "net"))))]
             $item
         )*

--- a/tokio/src/net/mod.rs
+++ b/tokio/src/net/mod.rs
@@ -38,12 +38,12 @@ cfg_net! {
     pub use tcp::listener::TcpListener;
     pub use tcp::stream::TcpStream;
     cfg_not_wasi! {
-        #[cfg(not(target_env = "sgx"))]
+        #[cfg(not(any(target_env = "sgx", target_env = "fortanixvme")))]
         pub use tcp::socket::TcpSocket;
 
-        #[cfg(not(target_env = "sgx"))]
+        #[cfg(not(any(target_env = "sgx", target_env = "fortanixvme")))]
         mod udp;
-        #[cfg(not(target_env = "sgx"))]
+        #[cfg(not(any(target_env = "sgx", target_env = "fortanixvme")))]
         pub use udp::UdpSocket;
     }
 }

--- a/tokio/src/net/tcp/mod.rs
+++ b/tokio/src/net/tcp/mod.rs
@@ -3,7 +3,7 @@
 pub(crate) mod listener;
 
 cfg_not_wasi! {
-    #[cfg(not(target_env = "sgx"))]
+    #[cfg(not(any(target_env = "sgx", target_env = "fortanixvme")))]
     pub(crate) mod socket;
 }
 

--- a/tokio/src/net/tcp/stream.rs
+++ b/tokio/src/net/tcp/stream.rs
@@ -1169,7 +1169,7 @@ impl TcpStream {
         self.io.set_nodelay(nodelay)
     }
 
-    #[cfg(not(target_env = "sgx"))]
+    #[cfg(not(any(target_env = "sgx", target_env = "fortanixvme")))]
     cfg_not_wasi! {
         /// Reads the linger duration for this socket by getting the `SO_LINGER`
         /// option.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

Patch `tokio` to support `fortanixvme` target. `fortanixvme` target supported in rust toolchain does not support unix domain sockets. This prevents `tokio` and `socket2` (a dependency of `tokio`) from compiling. 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
1. Remove `socket2` crate as a dependency in case of `fortanixvme` target. 
2. Conditionally disable unix domain socket related modules for `fortanixvme` target. This is done by modifying `cfg_net_unix` macro to include modules only in case NON `fortanixvme` target.

Note that this branch is split of `tokio-1.36.0-sgx` branch as the patched branch would need to support both `sgx` and `fortanixvme` targets.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
